### PR TITLE
Correct Installation command in installation and quickstart

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@ Livewire is a Laravel package, so you will need to have a Laravel application up
 To install Livewire, open your terminal and navigate to your Laravel application directory, then run the following command:
 
 ```shell
-composer require livewire/livewire "^3.0@beta"
+composer require livewire/livewire "^3.0.*@beta"
 ```
 
 That's it — really. If you want more customization options, keep reading. Otherwise, you can jump right into using Livewire.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,7 @@ Before we start, make sure you have the following installed:
 From the root directory of your Laravel app, run the following [Composer](https://getcomposer.org/) command:
 
 ```shell
-composer require livewire/livewire "^3.0@beta"
+composer require livewire/livewire "^3.0.*@beta"
 ```
 
 ## Create a Livewire component


### PR DESCRIPTION
Hi all,

I went to install livewire for the first time, and the installation command errored out with the following error:

```
    - Root composer.json requires livewire/livewire 3.0@beta, found livewire/livewire[dev-throw-error-when-testing-non-livewire-class, ..., dev-bad-hotfix-test, v0.0.1, ..., v0.7.4, v1.0.0, ..., 1.x-dev, v2.0.0, ..., 2.x-dev, v3.0.0-beta.1, ..., v3.0.0-beta.7] but it does not match the constraint.
```

This PR provides a working install command.